### PR TITLE
small issue with `setparameters!`

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -108,7 +108,7 @@ function _setparameters!(a::AbstractAlgebraicAgent, parameters)
         merge!(params, parameters)
     elseif params isa AbstractArray
         params .= parameters
-    else @error("type $(typeof(t)) doesn't implement `_setparameters!`") end
+    else @error("type $(typeof(a)) doesn't implement `_setparameters!`") end
 
     params
 end

--- a/test/molecules/test.jl
+++ b/test/molecules/test.jl
@@ -43,7 +43,9 @@ entangle!(therapeutic_area2, demand_model_2)
 # extract parameters
 getparameters(pharma_model)
 # set parameters
-setparameters!(pharma_model, Dict("therapeutic_area1/demand" => [.02, .02]))
+@test getparameters(pharma_model)["therapeutic_area1/demand/"] == [.01, .01]
+setparameters!(pharma_model, Dict("therapeutic_area1/demand/" => [.02, .02]))
+@test getparameters(pharma_model)["therapeutic_area1/demand/"] == [.02, .02]
 
 #=
 discovery units will adjust its productivity based on market demand:

--- a/tutorials/molecules/tutorial.jl
+++ b/tutorials/molecules/tutorial.jl
@@ -43,7 +43,7 @@ entangle!(therapeutic_area2, demand_model_2)
 # extract parameters
 getparameters(pharma_model)
 # set parameters
-setparameters!(pharma_model, Dict("therapeutic_area1/demand" => [.02, .02]))
+setparameters!(pharma_model, Dict("therapeutic_area1/demand/" => [.02, .02]))
 
 #=
 discovery units will adjust its productivity based on market demand:


### PR DESCRIPTION
Hi AlgebraicAgents team,

I was going through the toy pharma example and noticed that the call to `setparameters!` to change the param vector of the first SDE model wasn't actually updating the parameters, it looks like it was due to the path lacking a trailing "/". I added a test to check that the parameters are indeed changed. I also changed the interpolated error in `_setparameters!` to use the right argument symbol.