### PR TITLE
immutable fields in `@aagent` macro; issue #4

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ Another package is **[GeneratedExpressions.jl](https://github.com/Merck/Generate
 
 ```julia
 # drug entity, lives in a therapeutic area
-@aagent SmallMolecule Molecule begin
+@aagent FreeAgent Molecule struct SmallMolecule
     age::Float64
     birth_time::Float64
     kill_time::Float64

--- a/src/integrations/AgentsIntegration/core.jl
+++ b/src/integrations/AgentsIntegration/core.jl
@@ -6,7 +6,7 @@ export @get_model, @a
 
 # algebraic wrap for AgentBasedModel type
 ## algebraic agent types
-@aagent ABMAgent begin
+@aagent struct ABMAgent
     abm::Agents.AgentBasedModel
 
     agent_step!; model_step! # evolutionary functions
@@ -145,7 +145,7 @@ function _reinit!(a::ABMAgent)
 end
 
 # algebraic wrappers for AbstractAgent type
-@aagent AAgent begin end
+@aagent struct AAgent end
 
 @doc "Algebraic wrap for `AbstractAgent` type." AAgent
 

--- a/src/integrations/AlgebraicDynamicsIntegration/core.jl
+++ b/src/integrations/AlgebraicDynamicsIntegration/core.jl
@@ -8,7 +8,7 @@ const GraphicalModelType = Union{AbstractResourceSharer, AbstractMachine}
 
 # define wrap types
 # `AbstractResourceSharer`, `AbstractMachine` wrap
-@aagent GraphicalAgent begin
+@aagent struct GraphicalAgent
     system::GraphicalModelType
 end
 

--- a/src/integrations/SciMLIntegration/core.jl
+++ b/src/integrations/SciMLIntegration/core.jl
@@ -7,7 +7,7 @@ export DiffEqAgent
 export push_ports_in!, push_exposed_ports!
 
 # define DE algebraic wrap
-@aagent DiffEqAgent begin
+@aagent struct DiffEqAgent
     integrator::DiffEqBase.DEIntegrator
 
     exposed_ports::Union{Dict{Any, Int}, Nothing}

--- a/test/agents.jl
+++ b/test/agents.jl
@@ -1,0 +1,71 @@
+using Test, AlgebraicAgents
+
+@testset "@aagent macro" begin
+    "docstring"
+    @aagent struct BaseAgent
+        mutable1
+        mutable2::Int
+    end
+    
+    @doc (@doc BaseAgent)
+    @aagent BaseAgent struct DerivedAgent
+        mutable3
+        mutable4::Int
+    end
+
+    @test BaseAgent <: AbstractAlgebraicAgent
+    @test fieldnames(BaseAgent) == (:uuid, :name, :parent, :inners, :relpathrefs, :opera, :mutable1, :mutable2)
+    @test fieldtype(BaseAgent, :mutable2) == Int
+
+    @test fieldnames(DerivedAgent) == (
+        :uuid, :name, :parent, :inners, :relpathrefs, :opera, :mutable1, 
+        :mutable2, :mutable3, :mutable4
+    )
+
+    @test fieldtype(DerivedAgent, :mutable2) == Int
+    @test fieldtype(DerivedAgent, :mutable4) == Int
+
+    if VERSION >= v"1.8"
+        @testset "@aagent macro with immutable fields" begin
+            "docstring"
+            @aagent struct BaseAgent_w_immutables
+                mutable1
+                mutable2::Int
+
+                const immutable1
+                const immutable2::Int
+            end
+            
+            @doc (@doc BaseAgent_w_immutables)
+            @aagent BaseAgent_w_immutables struct DerivedAgent_w_immutables
+                mutable3
+                mutable4::Int
+
+                const immutable3
+                const immutable4::Int
+            end
+
+            @test BaseAgent_w_immutables <: AbstractAlgebraicAgent
+            @test fieldnames(BaseAgent_w_immutables) == (
+                :uuid, :name, :parent, :inners, :relpathrefs, :opera, :mutable1,
+                :mutable2, :immutable1, :immutable2
+            )
+            @test isconst(BaseAgent_w_immutables, :immutable1)
+            @test !isconst(BaseAgent_w_immutables, :mutable1)
+            @test fieldtype(BaseAgent_w_immutables, :mutable2) == Int
+
+            @test fieldnames(DerivedAgent_w_immutables) == (
+                :uuid, :name, :parent, :inners, :relpathrefs, :opera, :mutable1, 
+                :mutable2, :immutable1, :immutable2, :mutable3, :mutable4, :immutable3,
+                :immutable4
+            )
+            @test isconst(DerivedAgent_w_immutables, :immutable1)
+            @test !isconst(DerivedAgent_w_immutables, :mutable1)
+            @test fieldtype(DerivedAgent_w_immutables, :mutable2) == Int
+
+            @test isconst(DerivedAgent_w_immutables, :immutable3)
+            @test !isconst(DerivedAgent_w_immutables, :mutable3)
+            @test fieldtype(DerivedAgent_w_immutables, :mutable4) == Int
+        end
+    end
+end

--- a/test/molecules/types.jl
+++ b/test/molecules/types.jl
@@ -22,7 +22,8 @@ abstract type Molecule <: AbstractAlgebraicAgent end
 const N = 3 # molecule params granularity
 
 ## drug entity, lives in a therapeutic area 
-@aagent SmallMolecule Molecule begin
+"Parametrized drug entity, lives in a therapeutic area."
+@aagent FreeAgent Molecule struct SmallMolecule
     age::Float64
     birth_time::Float64
     kill_time::Float64
@@ -33,11 +34,10 @@ const N = 3 # molecule params granularity
     sales::Float64
     df_sales::DataFrame
 end
-
-@doc "Parametrized drug entity, lives in a therapeutic area." SmallMolecule
 
 ## drug entity, lives in a therapeutic area
-@aagent LargeMolecule Molecule begin
+@doc (@doc SmallMolecule)
+@aagent FreeAgent Molecule struct LargeMolecule
     age::Float64
     birth_time::Float64
     kill_time::Float64
@@ -48,12 +48,11 @@ end
     sales::Float64
     df_sales::DataFrame
 end
-
-@doc (@doc SmallMolecule) LargeMolecule
 
 ## toy discovery unit - outputs small/large molecules
 ## to a given therapeutic area
-@aagent Discovery begin
+"Toy discovery unit; outputs small and large molecules."
+@aagent struct Discovery
     rate_small::Float64
     rate_large::Float64
     productivity::Float64
@@ -67,8 +66,6 @@ end
 
     df_output::DataFrame
 end
-
-@doc "Toy discovery unit; outputs small and large molecules." Discovery
 
 # constructors
 "Initialize a discovery unit, parametrized by small/large molecules production rate."

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using SafeTestsets, BenchmarkTools
 
 @time begin
+    @time @safetestset "@aagent macro tests" begin include("agents.jl") end
     @time @safetestset "SciML integration tutorial" begin include("sciml/sciml_test.jl") end
     @time @safetestset "Agents.jl integration tutorial" begin include("agents/sir_test.jl") end
     @time @safetestset "toy pharma model tutorial test" begin include("molecules/test.jl") end

--- a/tutorials/molecules/types.jl
+++ b/tutorials/molecules/types.jl
@@ -22,7 +22,8 @@ abstract type Molecule <: AbstractAlgebraicAgent end
 const N = 3 # molecule params granularity
 
 ## drug entity, lives in a therapeutic area 
-@aagent SmallMolecule Molecule begin
+"Parametrized drug entity, lives in a therapeutic area."
+@aagent FreeAgent Molecule struct SmallMolecule
     age::Float64
     birth_time::Float64
     kill_time::Float64
@@ -33,11 +34,10 @@ const N = 3 # molecule params granularity
     sales::Float64
     df_sales::DataFrame
 end
-
-@doc "Parametrized drug entity, lives in a therapeutic area." SmallMolecule
 
 ## drug entity, lives in a therapeutic area
-@aagent LargeMolecule Molecule begin
+@doc (@doc SmallMolecule)
+@aagent FreeAgent Molecule struct LargeMolecule
     age::Float64
     birth_time::Float64
     kill_time::Float64
@@ -48,12 +48,10 @@ end
     sales::Float64
     df_sales::DataFrame
 end
-
-@doc (@doc SmallMolecule) LargeMolecule
 
 ## toy discovery unit - outputs small/large molecules
 ## to a given therapeutic area
-@aagent Discovery begin
+@aagent struct Discovery
     rate_small::Float64
     rate_large::Float64
     productivity::Float64

--- a/tutorials/traces/types.jl
+++ b/tutorials/traces/types.jl
@@ -19,7 +19,8 @@ const uncertainty_threshold = .2
 const init_belief_generator = (r = rand(N); r ./ sum(r))
 
 # candidate molecule; carries a scientist's belief about its activity
-@aagent Molecule AbstractMolecule begin
+"Candidate molecule, parametrized by a chemical fingerprint."
+@aagent FreeAgent AbstractMolecule struct Molecule
     birth_time::Float64
     decision_time::Union{Float64, Missing}
 
@@ -32,13 +33,12 @@ const init_belief_generator = (r = rand(N); r ./ sum(r))
     trace::Vector{<:Any}
 end
 
-@doc "Candidate molecule, parametrized by a chemical fingerprint." Molecule
-
 # preclinical experiments
 abstract type AbstractAssay <: AbstractAlgebraicAgent end
 
 # parametric experiment; updates belief about candidate's activity
-@aagent Assay AbstractAssay begin
+"Parametric experiment, updates belief about candidate's activity."
+@aagent FreeAgent AbstractAssay struct Assay 
     duration::Float64
     cost::Float64
     capacity::Float64
@@ -51,10 +51,8 @@ abstract type AbstractAssay <: AbstractAlgebraicAgent end
     t::Float64; t0::Float64
 end
 
-@doc "Parametric experiment, updates belief about candidate's activity."
-
 ## toy discovery unit - emits molecules with chemical fingerprints
-@aagent Discovery begin
+@aagent struct Discovery
     rate::Float64 # expected number of mols per unit step
 
     t::Float64
@@ -64,7 +62,8 @@ end
 end
 
 ## toy preclinical development model - orchestrates experiments, runs queries
-@aagent Preclinical begin
+"Toy discovery unit; emits molecules."
+@aagent struct Preclinical
     queries_accept::Vector{AlgebraicAgents.AbstractQuery}
     queries_reject::Vector{AlgebraicAgents.AbstractQuery}
 
@@ -75,8 +74,6 @@ end
     t::Float64; t0::Float64
     dt::Float64
 end
-
-@doc "Toy discovery unit; emits molecules." Discovery
 
 # constructors
 "Emit a candidate molecule."


### PR DESCRIPTION
 - breaking: add support for immutable fields in `@aagent` macro, change macro syntax
 - remove redundant `define_agent_*` constructors
 - support docstrings for `@aagent` output
 - update tests, add `@aagent` test