### PR TITLE
refactor `@aagent` constructor; issue #5

### DIFF
--- a/src/AlgebraicAgents.jl
+++ b/src/AlgebraicAgents.jl
@@ -60,8 +60,9 @@ export step!, simulate
 export draw
 
 # convenient algebraic agent subtyping
-include("agent_macros.jl")
+include("agents.jl")
 export @aagent
+export setup_agent!
 
 # algebraic agents' structure walking
 include("walks.jl")

--- a/src/integrations/AlgebraicDynamicsIntegration/core.jl
+++ b/src/integrations/AlgebraicDynamicsIntegration/core.jl
@@ -8,13 +8,6 @@ const GraphicalModelType = Union{AbstractResourceSharer, AbstractMachine}
 
 # define wrap types
 # `AbstractResourceSharer`, `AbstractMachine` wrap
-@aagent struct GraphicalAgent
-    system::GraphicalModelType
-end
-
-@doc "A wrap of either an `AbstractResourceSharer` or a `AbstractMachine`." GraphicalAgent
-
-# implement agent constructor
 """
     GraphicalAgent(name, model)
 Initialize algebraic wrap of either an `AbstractResourceSharer` or a `AbstractMachine`.
@@ -26,12 +19,8 @@ The wrapped `AbstractResourceSharer` or `AbstractMachine` is stored as the prope
 GraphicalAgent("rabbit", ContinuousMachine{Float64}(1,1,1, dotr, (u, p, t) -> u))
 ```
 """
-function GraphicalAgent(name::AbstractString, sharer::GraphicalModelType)
-    # initialize wrap
-    i = GraphicalAgent(name)
-    i.system = sharer
-
-    i
+@aagent struct GraphicalAgent
+    system::GraphicalModelType
 end
 
 function _construct_agent(name::AbstractString, sharer::GraphicalModelType, args...; kwargs...)

--- a/test/agents.jl
+++ b/test/agents.jl
@@ -75,7 +75,7 @@ using Test, AlgebraicAgents
             myname2::P
         end
 
-        a = MyAgent{Float64, Int}("myagent")
+        a = MyAgent{Float64, Int}("myagent", 1, 2)
         @test a isa MyAgent{Float64, Int}
     end
 end

--- a/test/molecules/types.jl
+++ b/test/molecules/types.jl
@@ -70,14 +70,9 @@ end
 # constructors
 "Initialize a discovery unit, parametrized by small/large molecules production rate."
 function Discovery(name, rate_small, rate_large, t=.0; dt=2.)
-    i = Discovery(name)
+    df_output = DataFrame(time=Float64[], small=Int[], large=Int[], removed=Int[])
 
-    i.rate_small = rate_small; i.rate_large = rate_large; i.productivity = .0
-    i.removed_mols = Tuple{String, Float64}[]
-    i.df_output = DataFrame(time=Float64[], small=Int[], large=Int[], removed=Int[])
-    i.t = i.t0 = t; i.dt = dt
-
-    i
+    Discovery(name, rate_small, rate_large, 0., t, dt, t, Tuple{String, Float64}[], df_output)
 end
 
 "Return initial sales volume of a molecule."
@@ -87,8 +82,8 @@ const sales0_factor_small = rand(N)
 const sales0_factor_large = rand(N)
 
 # dispatch on molecule type
-sales0_from_params(mol::SmallMolecule) = 10^3 * (1 + collect(mol.profile)' * sales0_factor_small)
-sales0_from_params(mol::LargeMolecule) = 10^5 * (1 + collect(mol.profile)' * sales0_factor_large)
+sales0_from_params(profile) = 10^3 * (1 + collect(profile)' * sales0_factor_small)
+sales0_from_params(profile) = 10^5 * (1 + collect(profile)' * sales0_factor_large)
 
 const sales_decay_small = .9
 const sales_decay_large = .7
@@ -174,13 +169,7 @@ end
 
 "Initialize a new molecule."
 function release_molecule(mol, profile, t, ::Type{T}) where T<:Molecule
-    i = T(mol)
-    i.age = .0; i.birth_time = t; i.kill_time = Inf
-    i.mol = mol; i.profile = profile
-    i.sales = sales0_from_params(i)
-    i.df_sales = DataFrame(time=Float64[], sales=Float64[])
-
-    i
+    T(mol, .0, t, Inf, mol, profile, sales0_from_params(profile), DataFrame(time=Float64[], sales=Float64[]))
 end
 
 AlgebraicAgents._projected_to(dx::Discovery) = dx.t

--- a/tutorials/molecules/types.jl
+++ b/tutorials/molecules/types.jl
@@ -71,14 +71,9 @@ end
 # constructors
 "Initialize a discovery unit, parametrized by small/large molecules production rate."
 function Discovery(name, rate_small, rate_large, t=.0; dt=2.)
-    i = Discovery(name)
+    df_output = DataFrame(time=Float64[], small=Int[], large=Int[], removed=Int[])
 
-    i.rate_small = rate_small; i.rate_large = rate_large; i.productivity = .0
-    i.removed_mols = Tuple{String, Float64}[]
-    i.df_output = DataFrame(time=Float64[], small=Int[], large=Int[], removed=Int[])
-    i.t = i.t0 = t; i.dt = dt
-
-    i
+    Discovery(name, rate_small, rate_large, 0., t, dt, t, Tuple{String, Float64}[], df_output)
 end
 
 "Return initial sales volume of a molecule."
@@ -175,13 +170,7 @@ end
 
 "Initialize a new molecule."
 function release_molecule(mol, profile, t, ::Type{T}) where T<:Molecule
-    i = T(mol)
-    i.age = .0; i.birth_time = t; i.kill_time = Inf
-    i.mol = mol; i.profile = profile
-    i.sales = sales0_from_params(i)
-    i.df_sales = DataFrame(time=Float64[], sales=Float64[])
-
-    i
+    T(mol, .0, t, Inf, mol, profile, sales0_from_params(i), DataFrame(time=Float64[], sales=Float64[]))
 end
 
 AlgebraicAgents._projected_to(dx::Discovery) = dx.t

--- a/tutorials/traces/types.jl
+++ b/tutorials/traces/types.jl
@@ -78,58 +78,33 @@ end
 # constructors
 "Emit a candidate molecule."
 function Molecule(mol, fingerprint, t, path=AbstractString[])
-    i = Molecule(mol)
-
-    i.birth_time = t; i.decision_time = missing
-    i.is_allocated = false
-    i.fingerprint = fingerprint; i.belief = init_belief_from_fingerprint(i)
-    i.trace = []; i.path = path
-    
-    i
+    Molecule(mol, t, missing, fingerprint, path, false, init_belief_from_fingerprint(i), [])
 end
 
 "Initialize a discovery unit, parametrized by molecule production rate."
 function Discovery(name, rate, t=.0; dt=2.)
-    i = Discovery(name)
-
-    i.rate = rate
-    i.t = i.t0 = t; i.dt = dt
-
-    i
+    Discovery(name, rate, t, dt, t0)
 end
 
 "Initialize an assay, parametrized by duration, cost, capacity, and a belief model."
 function Assay(name, duration::Float64, cost::Float64, capacity::Float64, belief_model=tuple(rand(-1:1, 5)...), t=.0)
-    i = Assay(name)
-
-    i.duration = duration; i.cost = cost; i.capacity = capacity
-    i.belief_model = belief_model
-
-    i.t = i.t0 = t
-
-    i.allocated = Vector{AlgebraicAgents.UUID}(undef, 0)
-    i.planned = Vector{AlgebraicAgents.UUID}(undef, 0)
-
-    i
+    Assay(name, duration, cost, capacity, belief_model, 
+        Vector{AlgebraicAgents.UUID}(undef, 0), Vector{AlgebraicAgents.UUID}(undef, 0),
+        t, t
+    )
 end
 
 "Initialize a preclinical unit comprising candidate molecules and parametrized by removal queries."
 function Preclinical(name, perturb_rate::Float64, t=.0; dt=1.,
         queries_accept=AlgebraicAgents.AbstractQuery[], queries_reject=AlgebraicAgents.AbstractQuery[])
-    i = Preclinical(name)
-
-    i.queries_accept = queries_accept
-    i.queries_reject = queries_reject
-    i.total_costs = .0; i.perturb_rate = perturb_rate
-
-    i.t = i.t0 = t; i.dt = dt
+    p = Preclinical(name, queries_accept, queries_reject, .0, perturb_rate, t, t, dt)
 
     # candidates and accepted, rejected candidates
-    entangle!(i, FreeAgent("candidates"))
-    entangle!(i, FreeAgent("accepted"))
-    entangle!(i, FreeAgent("rejected"))
+    entangle!(p, FreeAgent("candidates"))
+    entangle!(p, FreeAgent("accepted"))
+    entangle!(p, FreeAgent("rejected"))
 
-    i
+    p
 end
 
 # implement common interface


### PR DESCRIPTION
 - the type constructor provided by `@aagent` now requires extra fields at the input
 - for SciML/Agents integrations, define agent types without the use of `@aagent` macro