### PR TITLE
fix `push_ports_in!` and draft test of coupling dynamics with observables

### DIFF
--- a/src/integrations/SciMLIntegration/core.jl
+++ b/src/integrations/SciMLIntegration/core.jl
@@ -114,15 +114,17 @@ optionally be an iterable collection of observables' names.
 
 # Examples
 ```julia
-push_exposed_ports!(deagent, path => observable, path => [observables...])
+push_ports_in!(deagent, path => observable, path => [observables...])
 ```
 """
 function push_ports_in!(a::DiffEqAgent, pairs...)
-    isdefined(a, :exposed_ports) || (a.exposed_ports = [])
+    if isdefined(a, :ports_in) || isnothing(a.ports_in)
+        a.ports_in = []
+    end
     for id in pairs
-        if id[2] isa Union{AbstractVec, Tuple}
-            for o in id[2] push!(a.exposed_ports, id[1] => o) end
-        else push!(a.exposed_ports, id) end
+        if id[2] isa Union{AbstractVector, Tuple}
+            for o in id[2] push!(a.ports_in, id[1] => o) end
+        else push!(a.ports_in, id) end
     end
 
     a

--- a/test/sciml/sciml_test.jl
+++ b/test/sciml/sciml_test.jl
@@ -97,8 +97,8 @@ draw(sol, "diagram1/model1")
     py = (β = 1.2,)
     y0 = [1.0]
 
-    agent_x = DiffEqAgent("agent_x", ODEProblem(ẋ,x0,tspan,px), dt=0.00001)
-    agent_y = DiffEqAgent("agent_y", ODEProblem(ẏ,y0,tspan,py), dt=0.00001)
+    agent_x = DiffEqAgent("agent_x", ODEProblem(ẋ,x0,tspan,px))
+    agent_y = DiffEqAgent("agent_y", ODEProblem(ẏ,y0,tspan,py))
 
     push_exposed_ports!(agent_x, "x" => 1)
     push_exposed_ports!(agent_y, "y" => 1)

--- a/test/sciml/sciml_test.jl
+++ b/test/sciml/sciml_test.jl
@@ -75,3 +75,46 @@ sol = AlgebraicAgents.simulate(m)
 
 # plot solution
 draw(sol, "diagram1/model1")
+
+# output ports can couple dynamics
+@testset "observable (output) ports" begin
+
+    tspan = (0.0, 5.0)
+
+    function ẋ(u,p,t)
+        agent = @get_agent p
+        y = getobservable(getagent(agent, "../agent_y"), "y")
+        return [p.α * y]
+    end
+    px = (α = 0.5,)
+    x0 = [0.1]
+
+    function ẏ(u,p,t)
+        agent = @get_agent p
+        x = getobservable(getagent(agent, "../agent_x"), "x")
+        return [p.β * x]
+    end
+    py = (β = 1.2,)
+    y0 = [1.0]
+
+    agent_x = DiffEqAgent("agent_x", ODEProblem(ẋ,x0,tspan,px), dt=0.00001)
+    agent_y = DiffEqAgent("agent_y", ODEProblem(ẏ,y0,tspan,py), dt=0.00001)
+
+    push_exposed_ports!(agent_x, "x" => 1)
+    push_exposed_ports!(agent_y, "y" => 1)
+    
+    joint_system = ⊕(agent_x, agent_y; name="joint_system")
+
+    sol = AlgebraicAgents.simulate(joint_system)
+
+    y = getobservable(getagent(joint_system, "agent_y"), "y")
+    x = getobservable(getagent(joint_system, "agent_x"), "x")
+
+    A = [0 px.α; py.β 0]
+    z0 = [x0[1], y0[1]]
+
+    zt = exp(A*tspan[2]) * z0
+
+    @test zt[1] ≈ x
+    @test zt[2] ≈ y
+end

--- a/test/sciml/sciml_test.jl
+++ b/test/sciml/sciml_test.jl
@@ -79,7 +79,7 @@ draw(sol, "diagram1/model1")
 # output ports can couple dynamics
 @testset "observable (output) ports" begin
 
-    tspan = (0.0, 5.0)
+    tspan = (0.0, 10.0)
 
     function ẋ(u,p,t)
         agent = @get_agent p

--- a/test/sciml/sciml_test.jl
+++ b/test/sciml/sciml_test.jl
@@ -79,7 +79,7 @@ draw(sol, "diagram1/model1")
 # output ports can couple dynamics
 @testset "observable (output) ports" begin
 
-    tspan = (0.0, 10.0)
+    tspan = (0.0, 4.0)
 
     function ẋ(u,p,t)
         agent = @get_agent p
@@ -97,8 +97,8 @@ draw(sol, "diagram1/model1")
     py = (β = 1.2,)
     y0 = [1.0]
 
-    agent_x = DiffEqAgent("agent_x", ODEProblem(ẋ,x0,tspan,px))
-    agent_y = DiffEqAgent("agent_y", ODEProblem(ẏ,y0,tspan,py))
+    agent_x = DiffEqAgent("agent_x", ODEProblem(ẋ,x0,tspan,px), Euler(), dt = 1e-4)
+    agent_y = DiffEqAgent("agent_y", ODEProblem(ẏ,y0,tspan,py), Euler(), dt = 1e-4)
 
     push_exposed_ports!(agent_x, "x" => 1)
     push_exposed_ports!(agent_y, "y" => 1)
@@ -115,6 +115,6 @@ draw(sol, "diagram1/model1")
 
     zt = exp(A*tspan[2]) * z0
 
-    @test zt[1] ≈ x
-    @test zt[2] ≈ y
+    @test isapprox(zt[1], x, rtol = 1e-2)
+    @test isapprox(zt[2], y, rtol = 1e-2)
 end


### PR DESCRIPTION
Hi @thevolatilebit, this is a draft PR I am working on to implement a few more tests and eventually some more documentation regarding the SciML integration. I am opening it now to get your input on something before I'm ready to request another review for merging.

I was trying to set up a simple test of coupling a system of 2 agents [here](https://github.com/slwu89/AlgebraicAgents.jl/blob/600677e8f0bba0e0219060a77dbf8f4cc3ddc02d/test/sciml/sciml_test.jl#L79) to test coupling dynamics via the observables interface:

$$
\begin{equation}
\begin{aligned}
\dot{x} &= \alpha y \\
\dot{y} &= \beta x
\end{aligned}
\end{equation}
$$

However I'm not able to get output that is very close to the matrix exponential solution as I'd expect. Can you help me understand what I'm doing wrong here?

I also noticed that sometimes after calling `AlgebraicAgents.simulate` the times of the integrator objects was not the same. Solving out to `t=10.0` I got:

```julia
julia> agent_x
agent agent_x with uuid b7761b0d of type DiffEqAgent 
   custom properties:
   integrator: 
t: 10.0
u: 1-element Vector{Float64}:
 42.88439103151734
   ports out: x
   parent: joint_system

julia> agent_y
agent agent_y with uuid 676e9661 of type DiffEqAgent 
   custom properties:
   integrator: 
t: 6.285345087673145
u: 1-element Vector{Float64}:
 11.066342568141208
   ports out: y
   parent: joint_system
```