### PR TITLE
syncing SciML agents

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -176,16 +176,14 @@ function step!(a::AbstractAlgebraicAgent, t=projected_to(a); isroot=true)
 
     # first into the depth
     ret = nothing; foreach(values(inners(a))) do a
-        # @ret ret step!(a, t; isroot=false)
-        ret = AlgebraicAgents.ret(ret, step!(a, t; isroot=false))
+        @ret ret step!(a, t; isroot=false)
     end
 
     # local step implementation
     (_projected_to(a) == t) && _step!(a, t)
-    # @ret ret _projected_to(a)
-    ret = AlgebraicAgents.ret(ret, _projected_to(a))
+    @ret ret _projected_to(a)
 
-    # algebraic interactions
+    # @ret ret _step!(a, t) # local step implementation
     isroot && opera_run!(getopera(a))
 
     ret
@@ -198,8 +196,7 @@ Else return the minimum time up to which the evolution of an algebraic agent, an
 """
 function projected_to(a::AbstractAlgebraicAgent)
     ret = _projected_to(a); foreach(values(inners(a))) do a
-        # @ret ret projected_to(a)
-        ret = AlgebraicAgents.ret(ret, projected_to(a))
+        @ret ret projected_to(a)
     end
 
     ret

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -176,10 +176,16 @@ function step!(a::AbstractAlgebraicAgent, t=projected_to(a); isroot=true)
 
     # first into the depth
     ret = nothing; foreach(values(inners(a))) do a
-        @ret ret step!(a, t; isroot=false)
+        # @ret ret step!(a, t; isroot=false)
+        ret = AlgebraicAgents.ret(ret, step!(a, t; isroot=false))
     end
 
-    @ret ret _step!(a, t) # local step implementation
+    # local step implementation
+    (_projected_to(a) == t) && _step!(a, t)
+    # @ret ret _projected_to(a)
+    ret = AlgebraicAgents.ret(ret, _projected_to(a))
+
+    # algebraic interactions
     isroot && opera_run!(getopera(a))
 
     ret
@@ -192,7 +198,8 @@ Else return the minimum time up to which the evolution of an algebraic agent, an
 """
 function projected_to(a::AbstractAlgebraicAgent)
     ret = _projected_to(a); foreach(values(inners(a))) do a
-        @ret ret projected_to(a)
+        # @ret ret projected_to(a)
+        ret = AlgebraicAgents.ret(ret, projected_to(a))
     end
 
     ret

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,48 +1,20 @@
 "Return code propagation."
-# macro ret(old, ret)
-#     quote
-#         ret = $(esc(ret)); old = $(esc(old))
-#         val = if isnothing(ret) old
-#         elseif isnothing(old) ret
-#         elseif !isa(ret, Bool) && !isa(old, Bool)
-#             min(old, ret)
-#         else old end
-        
-#         $(esc(old)) = val
-#     end
-# end
-
-
-
-@generated function ret(old, ret)
-    if old <: Bool && (ret <: Bool || ret <: Nothing)
-        quote
-            true
-        end
-    elseif old <: Bool && ret <: Number
-        quote
+macro ret(old, ret)
+    quote
+        ret = $(esc(ret)); old = $(esc(old))
+        val = if isnothing(old)
             ret
-        end
-    elseif old <: Nothing && ret <: Bool
-        quote
-            true
-        end
-    elseif old <: Nothing && ret <: Nothing
-        quote
-            nothing
-        end
-    elseif old <: Nothing && ret <: Number
-        quote
+        elseif isnothing(ret)
+            old
+        elseif !isa(ret, Bool) && !isa(old, Bool)
+            min(old, ret)
+        elseif !isa(ret, Bool)
             ret
-        end
-    elseif old <: Number && (ret <: Bool || ret <: Nothing)
-        quote
+        else
             old
         end
-    elseif old <: Number && ret <: Number
-        quote
-            min(old, ret)
-        end
+     
+        $(esc(old)) = val
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,14 +1,48 @@
 "Return code propagation."
-macro ret(old, ret)
-    quote
-        ret = $(esc(ret)); old = $(esc(old))
-        val = if isnothing(ret) old
-        elseif isnothing(old) ret
-        elseif !isa(ret, Bool) && !isa(old, Bool)
-            min(old, ret)
-        else old end
+# macro ret(old, ret)
+#     quote
+#         ret = $(esc(ret)); old = $(esc(old))
+#         val = if isnothing(ret) old
+#         elseif isnothing(old) ret
+#         elseif !isa(ret, Bool) && !isa(old, Bool)
+#             min(old, ret)
+#         else old end
         
-        $(esc(old)) = val
+#         $(esc(old)) = val
+#     end
+# end
+
+
+
+@generated function ret(old, ret)
+    if old <: Bool && (ret <: Bool || ret <: Nothing)
+        quote
+            true
+        end
+    elseif old <: Bool && ret <: Number
+        quote
+            ret
+        end
+    elseif old <: Nothing && ret <: Bool
+        quote
+            true
+        end
+    elseif old <: Nothing && ret <: Nothing
+        quote
+            nothing
+        end
+    elseif old <: Nothing && ret <: Number
+        quote
+            ret
+        end
+    elseif old <: Number && (ret <: Bool || ret <: Nothing)
+        quote
+            old
+        end
+    elseif old <: Number && ret <: Number
+        quote
+            min(old, ret)
+        end
     end
 end
 

--- a/test/sciml/sciml_test.jl
+++ b/test/sciml/sciml_test.jl
@@ -118,3 +118,25 @@ draw(sol, "diagram1/model1")
     @test isapprox(zt[1], x, rtol = 1e-2)
     @test isapprox(zt[2], y, rtol = 1e-2)
 end
+
+# @aagent FreeAgent struct MyAgent{T<:AbstractString}
+#     myname::T
+# end
+
+# @aagent FreeAgent struct MyAgent1{T<:AbstractString}
+#     myname::T
+# end
+
+# AlgebraicAgents._projected_to(a::MyAgent{T}) where {T} = true
+# AlgebraicAgents._projected_to(a::MyAgent1{T}) where {T} = nothing
+
+# a = MyAgent{String}("alice", "alice")
+# b = MyAgent1{String}("bob", "bob")
+
+# agents = ⊕(a,b; name="joint")
+
+# AlgebraicAgents.projected_to(agents)
+
+# x = nothing
+
+# AlgebraicAgents.@ret x AlgebraicAgents._projected_to(b)

--- a/test/sciml/sciml_test.jl
+++ b/test/sciml/sciml_test.jl
@@ -150,4 +150,5 @@ end
     sol = AlgebraicAgents.simulate(joint_system)
 
     @test getagent(joint_system, "agent_y").integrator.t == getagent(joint_system, "agent_x").integrator.t
+    @test getagent(joint_system, "agent_y").integrator.t == tspan[2]
 end


### PR DESCRIPTION
This PR should address #10:

1. I updated `step!` as suggested
2. I updated the `@ret` macro to take into account a case which was previously not properly accounted for (when `Ret` is of a numeric type and `Old` is of a Boolean type, in this case we should update `val = ret` and overwrite `old` with the numeric value).
3. Added a test where default SciML integrators are allowed to choose their adaptive step size and solve for a longer period of time, then check that they are in sync at the end.