### PR TITLE
additions to `typetree_mmd`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -260,6 +260,4 @@ function typetree_mmd(T::Type, TT::Nothing = nothing; rem = false)
     ret
 end
 
-rem_module(T::Type, rem) = begin
-    rem ? string((T).name.name) : string(T)
-end
+rem_module(T::Type, rem) = begin rem ? string((T).name.name) : string(T) end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -234,13 +234,10 @@ print(join(typetree_mmd(Integer), ""))
 """
 function typetree_mmd(T::Type, TT::Type; rem = false)
     ret = Vector{String}()
-    # append!(ret, ["class $(T)\n"])
     append!(ret, ["class $(rem_module(T, rem))\n"])
     if isabstracttype(T)
-        # append!(ret, ["<<Abstract>> $(T)\n"])
         append!(ret, ["<<Abstract>> $(rem_module(T, rem))\n"])
     end
-    # append!(ret, ["$(TT) <|-- $(T)\n"])
     append!(ret, ["$(rem_module(TT, rem)) <|-- $(rem_module(T, rem))\n"])
     sub_types = [i for i in subtypes(T)]
     for i in 1:length(sub_types)
@@ -252,10 +249,8 @@ end
 function typetree_mmd(T::Type, TT::Nothing = nothing; rem = false)
     ret = Vector{String}()
     append!(ret, ["classDiagram\n"])
-    # append!(ret, ["class $(T)\n"])
     append!(ret, ["class $(rem_module(T, rem))\n"])
     if isabstracttype(T)
-        # append!(ret, ["<<Abstract>> $(T)\n"])
         append!(ret, ["<<Abstract>> $(rem_module(T, rem))\n"])
     end
     sub_types = [i for i in subtypes(T)]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,8 +1,8 @@
 using Test, AlgebraicAgents
 
 module MyModule
-    abstract type MySuperType end
-    abstract type MySubType <: MySuperType end
+abstract type MySuperType end
+abstract type MySubType <: MySuperType end
 end
 
 @testset "typetree_mmd" begin
@@ -13,6 +13,7 @@ end
     tt1 = typetree_mmd(Int64, Integer)
     @test tt1[2] == "Integer <|-- Int64\n"
 
-    typetree_mmd(MyModule.MySuperType, rem = false)[6] == "MyModule.MySuperType <|-- MyModule.MySubType\n"
+    typetree_mmd(MyModule.MySuperType, rem = false)[6] ==
+    "MyModule.MySuperType <|-- MyModule.MySubType\n"
     typetree_mmd(MyModule.MySuperType, rem = true)[6] == "MySuperType <|-- MySubType\n"
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,10 @@
 using Test, AlgebraicAgents
 
+module MyModule
+    abstract type MySuperType end
+    abstract type MySubType <: MySuperType end
+end
+
 @testset "typetree_mmd" begin
     tt = typetree_mmd(Int64)
     @test length(tt) == 2
@@ -7,4 +12,7 @@ using Test, AlgebraicAgents
 
     tt1 = typetree_mmd(Int64, Integer)
     @test tt1[2] == "Integer <|-- Int64\n"
+
+    typetree_mmd(MyModule.MySuperType, rem = false)[6] == "MyModule.MySuperType <|-- MyModule.MySubType\n"
+    typetree_mmd(MyModule.MySuperType, rem = true)[6] == "MySuperType <|-- MySubType\n"
 end


### PR DESCRIPTION
It seems Mermaid doesn't like period "." in names of classes in classDiagram (and other punctuation, see the issues here on their repo https://github.com/mermaid-js/mermaid/pull/1877). This PR adds the ability to strip off module prefixes from the printed typenames if desired, so that non exported typenames can be put into Mermaid diagrams more easily. 