### PR TITLE
option to append UUID

### DIFF
--- a/test/utils.jl
+++ b/test/utils.jl
@@ -25,11 +25,19 @@ end
     entangle!(base, AgentType1("agent2"))
     entangle!(base, AgentType1("agent3"))
 
+    # no uuid
     hierarchy = prewalk_ret(agent_hierarchy_mmd, base)
     hierarchy = cat(hierarchy..., dims = 1)
     @test hierarchy[1] == "classDiagram\n"
     @test hierarchy[2] == "class agent1\n"
     @test hierarchy[end] == "agent1 <|-- agent3\n"
+
+    # uuid
+    hierarchy = prewalk_ret(a -> agent_hierarchy_mmd(a, use_uuid = 2), base)
+    hierarchy = cat(hierarchy..., dims = 1)
+
+    @test occursin(r"[0-9]{2}", hierarchy[2][(end - 2):(end - 1)])
+    @test occursin(r"[0-9]{2}", hierarchy[3][(end - 2):(end - 1)])
 end
 
 @testset "postwalk and prewalk with return vals" begin


### PR DESCRIPTION
I realized that when looking at concrete hierarchies of agents, if multiple agents have the same name they will get mapped to the same mermaid node, making the visualization hard to figure out. I added an option to append the last `use_uuid` digits of the UUID to the name in this case.