### PR TITLE
simplify mmd tree prints

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -235,7 +235,8 @@ currently support "." characters in class names.
 print(join(typetree_mmd(Integer), ""))
 ```
 """
-function typetree_mmd(T::Type, TT::S=nothing; rem = false) where S<:Union{Type, Nothing}
+function typetree_mmd(T::Type, TT::S = nothing;
+                      rem = false) where {S <: Union{Type, Nothing}}
     ret = Vector{String}()
     if isnothing(TT)
         append!(ret, ["classDiagram\n"])

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -26,15 +26,13 @@ end
     entangle!(base, AgentType1("agent3"))
 
     # no uuid
-    hierarchy = prewalk_ret(agent_hierarchy_mmd, base)
-    hierarchy = cat(hierarchy..., dims = 1)
+    hierarchy = agent_hierarchy_mmd(base)
     @test hierarchy[1] == "classDiagram\n"
     @test hierarchy[2] == "class agent1\n"
     @test hierarchy[end] == "agent1 <|-- agent3\n"
 
     # uuid
-    hierarchy = prewalk_ret(a -> agent_hierarchy_mmd(a, use_uuid = 2), base)
-    hierarchy = cat(hierarchy..., dims = 1)
+    hierarchy = agent_hierarchy_mmd(base; use_uuid=2)
 
     @test occursin(r"[0-9]{2}", hierarchy[2][(end - 2):(end - 1)])
     @test occursin(r"[0-9]{2}", hierarchy[3][(end - 2):(end - 1)])

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -32,7 +32,7 @@ end
     @test hierarchy[end] == "agent1 <|-- agent3\n"
 
     # uuid
-    hierarchy = agent_hierarchy_mmd(base; use_uuid=2)
+    hierarchy = agent_hierarchy_mmd(base; use_uuid = 2)
 
     @test occursin(r"[0-9]{2}", hierarchy[2][(end - 2):(end - 1)])
     @test occursin(r"[0-9]{2}", hierarchy[3][(end - 2):(end - 1)])


### PR DESCRIPTION
I tried to simplify the interface to mdd tree prints somewhat:

 - former `agent_hierarchy_mmd` is now `_agent_hierarchy_mmd`; `agent_hierarchy_mmd` calls the `_*` internal function and concatenates the output vectors along the first dimension; moreover, we add the root `classDiagram` statement by default;
 - `typetree_mmd` is just a one function, to simplify the maintenance;

I updated the tests.