### PR TITLE
Getindex

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -279,7 +279,10 @@ function getobservable(a::AbstractAlgebraicAgent, args...)
     @error "algebraic agent $(typeof(a)) doesn't implement `getobservable`"
 end
 
-# implement `a[observable]` syntax
+"""
+    getindex(a::AbstractAlgebraicAgent, keys...)
+Get algebraic agent's observables using a convenient syntax.
+"""
 function Base.getindex(a::AbstractAlgebraicAgent, keys...)
     if isempty(keys)
         a
@@ -291,6 +294,25 @@ end
 "Get algebraic agent's observable at a given time."
 function gettimeobservable(a::AbstractAlgebraicAgent, ::Number, ::Any)
     @error "algebraic agent $(typeof(a)) doesn't implement `gettimeobservable`"
+end
+
+"""
+    getindex(a::FreeAgent, keys...)
+Get inner agents of a FreeAgent using a convenient syntax.
+# Examples
+```julia
+myagent = FreeAgent("root", [FreeAgent("a"),FreeAgent("b")])
+myagent["a"]
+myagent["a","b"]
+myagent[["a","b"]...]
+```
+"""
+function Base.getindex(a::FreeAgent, keys...)
+    if isempty(keys)
+        inners(a)
+    else
+        length(keys) > 1 ? getindex.(Ref(inners(a)), [keys...]) : [getindex(inners(a), only(keys))]
+    end
 end
 
 "Return a list of algebraic agent's inner ports (subjective observables)."

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -266,6 +266,26 @@ end
 _reinit!(::AbstractAlgebraicAgent) = nothing
 
 """
+    getindex(a::AbstractAlgebraicAgent, keys...)
+Get inner agents of an algebraic agent using a convenient syntax.
+# Examples
+```julia
+myagent = FreeAgent("root", [FreeAgent("a"),FreeAgent("b")])
+myagent["a"]
+myagent["a","b"]
+myagent[["a","b"]...]
+```
+"""
+function Base.getindex(a::AbstractAlgebraicAgent, keys...)
+    if isempty(keys)
+        inners(a)
+    else
+        length(keys) > 1 ? getindex.(Ref(inners(a)), [keys...]) :
+        [getindex(inners(a), only(keys))]
+    end
+end
+
+"""
     getobservable(agent, args...)
 Get algebraic agent's observable.
 
@@ -279,40 +299,9 @@ function getobservable(a::AbstractAlgebraicAgent, args...)
     @error "algebraic agent $(typeof(a)) doesn't implement `getobservable`"
 end
 
-"""
-    getindex(a::AbstractAlgebraicAgent, keys...)
-Get algebraic agent's observables using a convenient syntax.
-"""
-function Base.getindex(a::AbstractAlgebraicAgent, keys...)
-    if isempty(keys)
-        a
-    else
-        getobservable(a, keys...)
-    end
-end
-
 "Get algebraic agent's observable at a given time."
 function gettimeobservable(a::AbstractAlgebraicAgent, ::Number, ::Any)
     @error "algebraic agent $(typeof(a)) doesn't implement `gettimeobservable`"
-end
-
-"""
-    getindex(a::FreeAgent, keys...)
-Get inner agents of a FreeAgent using a convenient syntax.
-# Examples
-```julia
-myagent = FreeAgent("root", [FreeAgent("a"),FreeAgent("b")])
-myagent["a"]
-myagent["a","b"]
-myagent[["a","b"]...]
-```
-"""
-function Base.getindex(a::FreeAgent, keys...)
-    if isempty(keys)
-        inners(a)
-    else
-        length(keys) > 1 ? getindex.(Ref(inners(a)), [keys...]) : [getindex(inners(a), only(keys))]
-    end
 end
 
 "Return a list of algebraic agent's inner ports (subjective observables)."

--- a/test/agents.jl
+++ b/test/agents.jl
@@ -81,3 +81,13 @@ using Test, AlgebraicAgents
         @test a isa MyAgent{Float64, Int}
     end
 end
+
+@testset "getindex for FreeAgent" begin
+    myagent = FreeAgent("root", [FreeAgent("a"),FreeAgent("b")])
+    @test length(myagent["a"]) == 1
+    @test length(myagent["a","b"]) == 2
+    @test length(myagent[["a","b"]...]) == 2
+    @test myagent[] == inners(myagent)
+    @test_throws KeyError myagent[1]
+    @test_throws KeyError myagent["bbb"]
+end

--- a/test/agents.jl
+++ b/test/agents.jl
@@ -83,10 +83,10 @@ using Test, AlgebraicAgents
 end
 
 @testset "getindex for FreeAgent" begin
-    myagent = FreeAgent("root", [FreeAgent("a"),FreeAgent("b")])
+    myagent = FreeAgent("root", [FreeAgent("a"), FreeAgent("b")])
     @test length(myagent["a"]) == 1
-    @test length(myagent["a","b"]) == 2
-    @test length(myagent[["a","b"]...]) == 2
+    @test length(myagent["a", "b"]) == 2
+    @test length(myagent[["a", "b"]...]) == 2
     @test myagent[] == inners(myagent)
     @test_throws KeyError myagent[1]
     @test_throws KeyError myagent["bbb"]

--- a/test/integrations/sciml_test.jl
+++ b/test/integrations/sciml_test.jl
@@ -18,8 +18,6 @@ m3 = DiffEqAgent("model3", prob)
 ## it will be possible to reference m3's first variable as both `o1`, `o2`
 push_exposed_ports!(m3, "o1" => 1, "o2" => 1)
 
-@test m3["o2"] == getobservable(m3, "o2")
-
 ## simple function, calls to which will be scheduled during the model integration
 custom_function(agent, t) = 1#println(name(agent), " ", t)
 

--- a/test/integrations/sciml_test.jl
+++ b/test/integrations/sciml_test.jl
@@ -18,6 +18,8 @@ m3 = DiffEqAgent("model3", prob)
 ## it will be possible to reference m3's first variable as both `o1`, `o2`
 push_exposed_ports!(m3, "o1" => 1, "o2" => 1)
 
+@test m3["o2"] == getobservable(m3, "o2")
+
 ## simple function, calls to which will be scheduled during the model integration
 custom_function(agent, t) = 1#println(name(agent), " ", t)
 


### PR DESCRIPTION
Address #32. Because only FreeAgent and its subtypes will have `inners`, I just made a specialized method for that type. Because of type narrowing anything that inherits from FreeAgent should use `Base.getindex(::FreeAgent,...)`. Also added tests to make sure the existing implementation still works for `DiffEqAgents`. I think this is a good approach, balancing the two methods.

Also I'm not really sure why there are so many commits in this fork that aren't in main...I've merged with the upstream (Merck/AlgAgents) frequently to make sure they are up to date. Any suggestions as to what went wrong? 