### PR TITLE
fix `getindex`

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -275,9 +275,13 @@ myagent[:]
 """
 
 Base.getindex(a::AbstractAlgebraicAgent, key::AbstractString) = getindex(inners(a), key)
-Base.getindex(a::AbstractAlgebraicAgent, I::AbstractVector{<:AbstractString}) = getindex.(Ref(inners(a)), [I...])
+function Base.getindex(a::AbstractAlgebraicAgent, I::AbstractVector{<:AbstractString})
+    getindex.(Ref(inners(a)), [I...])
+end
 Base.getindex(a::AbstractAlgebraicAgent, ::Colon) = collect(values(inners(a)))
-Base.getindex(::AbstractAlgebraicAgent, args...) = throw(ArgumentError("invalid index: $(args) of type $(typeof(args))"))
+function Base.getindex(::AbstractAlgebraicAgent, args...)
+    throw(ArgumentError("invalid index: $(args) of type $(typeof(args))"))
+end
 
 """
     getobservable(agent, args...)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -269,18 +269,15 @@ Get inner agents of an agent using a convenient syntax.
 ```julia
 myagent = FreeAgent("root", [FreeAgent("a"),FreeAgent("b")])
 myagent["a"]
-myagent["a","b"]
-myagent[["a","b"]...]
+myagent[["a","b"]]
+myagent[:]
 ```
 """
-function Base.getindex(a::AbstractAlgebraicAgent, keys...)
-    if isempty(keys)
-        inners(a)
-    else
-        length(keys) > 1 ? getindex.(Ref(inners(a)), [keys...]) :
-        [getindex(inners(a), only(keys))]
-    end
-end
+
+Base.getindex(a::AbstractAlgebraicAgent, key::AbstractString) = getindex(inners(a), key)
+Base.getindex(a::AbstractAlgebraicAgent, I::AbstractVector{<:AbstractString}) = getindex.(Ref(inners(a)), [I...])
+Base.getindex(a::AbstractAlgebraicAgent, ::Colon) = collect(values(inners(a)))
+Base.getindex(::AbstractAlgebraicAgent, args...) = throw(ArgumentError("invalid index: $(args) of type $(typeof(args))"))
 
 """
     getobservable(agent, args...)

--- a/test/agents.jl
+++ b/test/agents.jl
@@ -84,10 +84,9 @@ end
 
 @testset "getindex for FreeAgent" begin
     myagent = FreeAgent("root", [FreeAgent("a"), FreeAgent("b")])
-    @test length(myagent["a"]) == 1
-    @test length(myagent["a", "b"]) == 2
-    @test length(myagent[["a", "b"]...]) == 2
-    @test myagent[] == inners(myagent)
-    @test_throws KeyError myagent[1]
+    @test myagent["a"] isa AbstractAlgebraicAgent
+    @test length(myagent[["a", "b"]]) == 2
+    @test myagent[:] == collect(values(inners(myagent)))
+    @test_throws ArgumentError myagent[1]
     @test_throws KeyError myagent["bbb"]
 end


### PR DESCRIPTION
fixes behaviour of `getindex(::AbstractAlgebraicAgent, I)`, so that

```julia
myagent = FreeAgent("root", [FreeAgent("a"),FreeAgent("b")])
myagent["a"] # FreeAgent("a")
myagent[["a","b"]] # [FreeAgent("a"),FreeAgent("b")]
myagent[:] # collect(values(inners(myagent)))
```

other indexing is unsupported and falls to `ArgumentError`