### PR TITLE
fix: bump Agents.jl compat to v7 and repair @a/@get_model macros

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ AlgebraicAgentsSciMLExt = "DifferentialEquations"
 AlgebraicAgentsSciMLPlotsExt = ["DifferentialEquations", "Plots"]
 
 [compat]
-Agents = "6"
+Agents = "7"
 AlgebraicDynamics = "0.2"
 Crayons = "4.1"
 DataFrames = "1.7.0"

--- a/ext/AlgebraicAgentsAgentsExt.jl
+++ b/ext/AlgebraicAgentsAgentsExt.jl
@@ -173,6 +173,10 @@ function AlgebraicAgents.extract_agent(model::Agents.ABM, agent::Agents.Abstract
     return Agents.abmproperties(model)[:__aagent__].inners[string(agent.id)]
 end
 
+# retrieve the algebraic wrap stored in an ABM's properties (used by `@get_model`, `@a`)
+AlgebraicAgents.get_abm_wrap(model::Agents.AgentBasedModel) =
+    Agents.abmproperties(model)[:__aagent__]
+
 # helper used by the `@a` macro
 function AlgebraicAgents.get_model(args...; kwargs...)
     vals = collect(args)

--- a/src/integrations/agents.jl
+++ b/src/integrations/agents.jl
@@ -91,7 +91,7 @@ Requires the `AlgebraicAgentsAgentsExt` extension (i.e. `Agents.jl` loaded).
 # Examples
 ```julia
 @a add_agent!(model, 0.5)
-@a disentangle!(agent, model)
+@a remove_agent!(agent, model)
 ```
 """
 macro a(call)
@@ -106,7 +106,8 @@ macro a(call)
             omodel = model isa ABMAgent ? model : AlgebraicAgents.get_abm_wrap(model)
             agent = $(esc(call))
 
-            entangle!(omodel, ABAModel(string(agent.id), a))
+            entangle!(omodel, AAgent(string(agent.id)))
+            agent
         end
     else
         agent = model_call.args[2]

--- a/src/integrations/agents.jl
+++ b/src/integrations/agents.jl
@@ -76,7 +76,10 @@ algebraic_model = @get_model abm_model
 ```
 """
 macro get_model(model)
-    return :(Agents.abmproperties($(esc(model)))[:__aagent__])
+    # `AlgebraicAgents.get_abm_wrap` is specialized in the Agents extension; we
+    # route through it instead of emitting a bare `Agents.abmproperties` call,
+    # which would resolve `Agents` in this module (a weakdep with no binding here).
+    return :(AlgebraicAgents.get_abm_wrap($(esc(model))))
 end
 
 """
@@ -100,7 +103,7 @@ macro a(call)
     return if call.args[1] == :add_agent!
         quote
             model = $(esc(model_call))
-            omodel = model isa ABMAgent ? model : Agents.abmproperties(model)[:__aagent__]
+            omodel = model isa ABMAgent ? model : AlgebraicAgents.get_abm_wrap(model)
             agent = $(esc(call))
 
             entangle!(omodel, ABAModel(string(agent.id), a))
@@ -109,7 +112,7 @@ macro a(call)
         agent = model_call.args[2]
         quote
             model = $(esc(model_call))
-            omodel = model isa ABMAgent ? model : Agents.abmproperties(model)[:__aagent__]
+            omodel = model isa ABMAgent ? model : AlgebraicAgents.get_abm_wrap(model)
 
             agent = $(esc(agent))
             agent = agent isa Number ? string(agent) : string(agent.id)
@@ -122,3 +125,8 @@ end
 
 # helper used by the `@a` macro; the extension specializes its dispatch.
 function get_model end
+
+# retrieves the algebraic wrap stored in an ABM's properties; specialized in the
+# `AlgebraicAgentsAgentsExt` extension. Used by `@get_model` and `@a` so the macros
+# need not reference the `Agents` weakdep directly.
+function get_abm_wrap end

--- a/test/integrations/agents_test.jl
+++ b/test/integrations/agents_test.jl
@@ -61,3 +61,35 @@ end
 
     @test draw(abm_algebraic_wrap) isa Plots.Plot
 end
+
+# Exercise the `@get_model` and `@a` macros from within a *stepped* model. These
+# macros expand to references that must resolve against the loaded Agents
+# extension rather than the `Agents` weakdep symbol inside `AlgebraicAgents`;
+# wiring them into `agent_step!` guards against that regression.
+function macro_agent_step!(agent, model)
+    @get_model model
+    extract_agent(model, agent)
+    # remove every infected agent via the algebraic `@a` wrapper
+    return if agent.status == :I
+        @a remove_agent!(agent, model)
+    end
+end
+
+@testset "`@get_model` and `@a` macros within stepping" begin
+    Random.seed!(1)
+    space = GraphSpace(Agents.Graphs.complete_graph(4))
+    abm_macro = StandardABM(
+        PoorSoul, space; agent_step! = macro_agent_step!, model_step! = identity,
+        properties = Dict{Symbol, Any}()
+    )
+    for _ in 1:20
+        add_agent!(rand(1:4), abm_macro, 0, :I)
+    end
+
+    abm_macro_wrap = ABMAgent("sir_macro_model", abm_macro; tspan = (0.0, 5.0))
+    # both macros are evaluated during stepping; this should not error
+    @test simulate(abm_macro_wrap) isa AlgebraicAgents.ABMAgent
+    # `@a remove_agent!` keeps the algebraic wrap's inners in sync with the ABM and
+    # removes the infected agents
+    @test length(inners(abm_macro_wrap)) == Agents.nagents(abm_macro_wrap.abm) == 0
+end

--- a/test/integrations/agents_test.jl
+++ b/test/integrations/agents_test.jl
@@ -93,3 +93,34 @@ end
     # removes the infected agents
     @test length(inners(abm_macro_wrap)) == Agents.nagents(abm_macro_wrap.abm) == 0
 end
+
+# `@a add_agent!` spawns a susceptible agent for each infected one, then recovers
+# the infected agent so the spawn happens exactly once per original agent.
+function add_agent_step!(agent, model)
+    @get_model model
+    return if agent.status == :I
+        new = @a add_agent!(agent.pos, model, 0, :S)
+        agent.status = :R
+        new
+    end
+end
+
+@testset "`@a add_agent!` keeps the wrap in sync" begin
+    Random.seed!(1)
+    space = GraphSpace(Agents.Graphs.complete_graph(4))
+    abm_add = StandardABM(
+        PoorSoul, space; agent_step! = add_agent_step!, model_step! = identity,
+        properties = Dict{Symbol, Any}()
+    )
+    for _ in 1:5
+        add_agent!(rand(1:4), abm_add, 0, :I)
+    end
+
+    abm_add_wrap = ABMAgent("add_model", abm_add; tspan = (0.0, 3.0))
+    simulate(abm_add_wrap)
+
+    # the five infected agents each spawned one susceptible agent
+    @test Agents.nagents(abm_add_wrap.abm) == 10
+    # `@a add_agent!` entangled each new agent, so inners track the ABM exactly
+    @test length(inners(abm_add_wrap)) == Agents.nagents(abm_add_wrap.abm)
+end

--- a/tutorials/agents/Manifest.toml
+++ b/tutorials/agents/Manifest.toml
@@ -34,22 +34,28 @@ version = "0.1.44"
     Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [[deps.Agents]]
-deps = ["CSV", "CommonSolve", "DataFrames", "DataStructures", "Distributed", "Distributions", "Downloads", "Graphs", "JLD2", "LazyArtifacts", "LightOSM", "LightSumTypes", "LinearAlgebra", "MacroTools", "PrecompileTools", "ProgressMeter", "Random", "Rotations", "Scratch", "StaticArrays", "StatsBase", "StreamSampling"]
-git-tree-sha1 = "fa3c05d96928a91cd0afc9a02134969e1b73d45d"
+deps = ["CSV", "CommonSolve", "DataFrames", "DataStructures", "Distributed", "Distributions", "Downloads", "Graphs", "JLD2", "LazyArtifacts", "LightSumTypes", "LinearAlgebra", "MacroTools", "PrecompileTools", "ProgressMeter", "Random", "Rotations", "StaticArrays", "StatsBase", "StreamSampling", "StructArrays"]
+git-tree-sha1 = "e821fd870cdc6308627c0c70d92847c14472c52f"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
-version = "6.2.10"
+version = "7.0.3"
 
     [deps.Agents.extensions]
     AgentsArrow = "Arrow"
     AgentsGraphVisualizations = ["Makie", "GraphMakie"]
-    AgentsOSMVisualizations = ["Makie", "OSMMakie"]
+    AgentsOSM = "LightOSM"
+    AgentsOSMVisualizations = ["Makie", "LightOSM", "OSMMakie"]
+    AgentsRL = ["Crux", "POMDPs", "Flux"]
     AgentsVisualizations = "Makie"
 
     [deps.Agents.weakdeps]
     Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
+    Crux = "e51cc422-768a-4345-bb8e-2246287ae729"
+    Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
     GraphMakie = "1ecd5474-83a3-4783-bb4f-06765db800d2"
+    LightOSM = "d1922b25-af4e-4ba3-84af-fe9bea896051"
     Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
     OSMMakie = "76b6901f-8821-46bb-9129-841bc9cfe677"
+    POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 
 [[deps.AlgebraicAgents]]
 deps = ["Crayons", "Glob", "InteractiveUtils", "MacroTools", "Random", "UUIDs"]
@@ -90,11 +96,6 @@ deps = ["LinearAlgebra", "Random", "StaticArrays"]
 git-tree-sha1 = "d57bd3762d308bded22c3b82d033bff85f6195c6"
 uuid = "ec485272-7323-5ecc-a04f-4719b315124d"
 version = "0.4.0"
-
-[[deps.ArrayTools]]
-git-tree-sha1 = "ca8c5218f18c5318827fdb1881f370249610f8d2"
-uuid = "1dc0ca97-c5ce-4e77-ac6d-c576ac9d7f27"
-version = "0.2.7"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -263,20 +264,6 @@ deps = ["Mmap"]
 git-tree-sha1 = "9e2f36d3c96a820c678f2f1f1782582fcf685bae"
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 version = "1.9.1"
-
-[[deps.Distances]]
-deps = ["LinearAlgebra", "Statistics", "StatsAPI"]
-git-tree-sha1 = "c7e3a542b999843086e2f29dac96a618c105be1d"
-uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-version = "0.10.12"
-
-    [deps.Distances.extensions]
-    DistancesChainRulesCoreExt = "ChainRulesCore"
-    DistancesSparseArraysExt = "SparseArrays"
-
-    [deps.Distances.weakdeps]
-    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[deps.Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
@@ -708,23 +695,11 @@ git-tree-sha1 = "d620582b1f0cbe2c72dd1d5bd195a9ce73370ab1"
 uuid = "38a345b3-de98-5d2b-a5d3-14cd9215e700"
 version = "2.42.0+0"
 
-[[deps.LightOSM]]
-deps = ["DataStructures", "Graphs", "HTTP", "JSON", "LightXML", "MetaGraphs", "NearestNeighbors", "Parameters", "QuickHeaps", "SimpleWeightedGraphs", "SparseArrays", "SpatialIndexing", "StaticArrays", "StaticGraphs", "Statistics"]
-git-tree-sha1 = "661e48d31c0471354dbd84f54b3177386f8b0b66"
-uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
-version = "0.3.2"
-
 [[deps.LightSumTypes]]
 deps = ["MacroTools", "PrecompileTools"]
 git-tree-sha1 = "a42e706a520af0c7d560dedbe4cded3a9b4356f0"
 uuid = "f56206fc-af4c-5561-a72a-43fe2ca5a923"
 version = "5.2.2"
-
-[[deps.LightXML]]
-deps = ["Libdl", "XML2_jll"]
-git-tree-sha1 = "aa971a09f0f1fe92fe772713a564aa48abe510df"
-uuid = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
-version = "0.9.3"
 
 [[deps.LinearAlgebra]]
 deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
@@ -784,12 +759,6 @@ git-tree-sha1 = "b513cedd20d9c914783d8ad83d08120702bf2c77"
 uuid = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
 version = "0.3.3"
 
-[[deps.MetaGraphs]]
-deps = ["Graphs", "JLD2", "Random"]
-git-tree-sha1 = "3a8f462a180a9d735e340f4e8d5f364d411da3a4"
-uuid = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
-version = "0.8.1"
-
 [[deps.Missings]]
 deps = ["DataAPI"]
 git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
@@ -809,12 +778,6 @@ deps = ["OpenLibm_jll"]
 git-tree-sha1 = "9b8215b1ee9e78a293f99797cd31375471b2bcae"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 version = "1.1.3"
-
-[[deps.NearestNeighbors]]
-deps = ["AbstractTrees", "Distances", "StaticArrays"]
-git-tree-sha1 = "e2c3bba08dd6dedfe17a17889131b885b8c082f0"
-uuid = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
-version = "0.4.27"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -890,12 +853,6 @@ deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "FriBidi_jl
 git-tree-sha1 = "58e5ed5e386e156bd93e86b305ebd21ac63d2d04"
 uuid = "36c8627f-9965-5494-a995-c6b170f724f3"
 version = "1.57.1+0"
-
-[[deps.Parameters]]
-deps = ["OrderedCollections", "UnPack"]
-git-tree-sha1 = "34c0e9ad262e5f7fc75b10a9952ca7692cfc5fbe"
-uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
-version = "0.12.3"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
@@ -1044,12 +1001,6 @@ git-tree-sha1 = "4d8c1b7c3329c1885b857abb50d08fa3f4d9e3c8"
 uuid = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
 version = "0.7.7"
 
-[[deps.QuickHeaps]]
-deps = ["ArrayTools", "DataStructures"]
-git-tree-sha1 = "ff720a9c8356004cc9e3d109cdcb327510345edc"
-uuid = "30b38841-0f52-47f8-a5f8-18d5d4064379"
-version = "0.1.2"
-
 [[deps.REPL]]
 deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
@@ -1165,12 +1116,6 @@ git-tree-sha1 = "be8eeac05ec97d379347584fa9fe2f5f76795bcb"
 uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 version = "0.9.5"
 
-[[deps.SimpleWeightedGraphs]]
-deps = ["Graphs", "LinearAlgebra", "Markdown", "SparseArrays"]
-git-tree-sha1 = "749a2b719ec7f34f280c0d97ac3dab5c89818631"
-uuid = "47aef6b3-ad0c-573a-a1e2-d07658019622"
-version = "1.5.1"
-
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 version = "1.11.0"
@@ -1185,11 +1130,6 @@ version = "1.2.2"
 deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 version = "1.12.0"
-
-[[deps.SpatialIndexing]]
-git-tree-sha1 = "84efe17c77e1f2156a7a0d8a7c163c1e1c7bdaed"
-uuid = "d4ead438-fe20-5cc5-a293-4fd39a41b74c"
-version = "0.1.6"
 
 [[deps.SpecialFunctions]]
 deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
@@ -1227,12 +1167,6 @@ version = "1.9.18"
 git-tree-sha1 = "6ab403037779dae8c514bad259f32a447262455a"
 uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 version = "1.4.4"
-
-[[deps.StaticGraphs]]
-deps = ["Graphs", "JLD2", "SparseArrays"]
-git-tree-sha1 = "18d30e8addbae91e7a63d56c21f5d7946d124702"
-uuid = "4c8beaf5-199b-59a0-a7f2-21d17de635b6"
-version = "0.3.1"
 
 [[deps.Statistics]]
 deps = ["LinearAlgebra"]
@@ -1281,6 +1215,27 @@ deps = ["PrecompileTools"]
 git-tree-sha1 = "d05693d339e37d6ab134c5ab53c29fce5ee5d7d5"
 uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
 version = "0.4.4"
+
+[[deps.StructArrays]]
+deps = ["ConstructionBase", "DataAPI", "Tables"]
+git-tree-sha1 = "ad8002667372439f2e3611cfd14097e03fa4bccd"
+uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+version = "0.7.3"
+
+    [deps.StructArrays.extensions]
+    StructArraysAdaptExt = "Adapt"
+    StructArraysGPUArraysCoreExt = ["GPUArraysCore", "KernelAbstractions"]
+    StructArraysLinearAlgebraExt = "LinearAlgebra"
+    StructArraysSparseArraysExt = "SparseArrays"
+    StructArraysStaticArraysExt = "StaticArrays"
+
+    [deps.StructArrays.weakdeps]
+    Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+    GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [[deps.StyledStrings]]
 uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
@@ -1385,12 +1340,6 @@ version = "1.4.3"
 git-tree-sha1 = "cd1659ba0d57b71a464a29e64dbc67cfe83d54e7"
 uuid = "76eceee3-57b5-4d4a-8e66-0e911cebbf60"
 version = "1.6.1"
-
-[[deps.XML2_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
-git-tree-sha1 = "5c959b708667b34cb758e8d7c6f8e69b94c32deb"
-uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.15.1+0"
 
 [[deps.XZ_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]


### PR DESCRIPTION
## Summary

Agents.jl v6 no longer precompiles against the current Distributions.jl (a `@check_args` macro incompatibility), which breaks CI on every job that loads the Agents integration. This PR bumps the compat bound to `Agents = "7"` and fixes two macro bugs that the bump surfaced.

- **`Project.toml`** — `Agents = "6"` → `Agents = "7"`. None of v7's breaking changes (plotting rewrite, `OpenStreetMapSpace` moved to an extension, route functions namespaced under `OSM`/`Pathfinding`, `ByKind` scheduler removed) touch the API the integration uses (`run!`, `StandardABM`, `abmproperties`, `add_agent!`, `remove_agent!`, `abmrng`, `allids`).
- **Macro hygiene fix (`@get_model`, `@a`)** — Both macros expanded to a bare `Agents.abmproperties(...)`. Since the Requires→extensions migration (`ee35767`), `Agents` is a weakdep with no binding inside `AlgebraicAgents`, so hygiene resolved the symbol there and threw `UndefVarError: Agents not defined in AlgebraicAgents`. Both macros now route through a new `get_abm_wrap` stub that is specialized in the extension — matching the existing `get_model`/`extract_agent` pattern.
- **`@a add_agent!` repair** — This branch expanded to `entangle!(omodel, ABAModel(string(agent.id), a))`, but `ABAModel` was never defined in any commit and `a` was an undefined free variable, so the branch errored on every use. The intended wrap is `AAgent` (the same type the `ABMAgent` constructor entangles for each existing agent). It now wraps the new agent as `AAgent(string(agent.id))` and returns the agent, mirroring `add_agent!`. The misleading `@a disentangle!(...)` docstring example — an op the macro's own `@assert` rejects — was corrected to `@a remove_agent!(...)`.
- **`tutorials/agents/Manifest.toml`** — regenerated to pin Agents 7.0.3 (tutorial Manifests are tracked for reproducibility).

## Why the bugs were invisible

The test suite defined an `agent_step!` that called `@get_model`, but it was never wired into the stepped model (the SIR constructor uses `sir_agent_step!`), so the macro never executed. Likewise, no test or tutorial ever called `@a add_agent!`. The failures only appeared when running the Agents tutorial end-to-end.

## Tests

Added two testsets that step models whose `agent_step!` actually exercises the macros:

- `@get_model` + `@a remove_agent!` within stepping — asserts the run doesn't error and the wrap's `inners` stay in sync with the ABM as agents are removed.
- `@a add_agent!` keeps the wrap in sync — asserts each spawned agent is entangled and `inners` tracks the ABM exactly.

Agents.jl integration testset went from 4 → 8 passing assertions.

## Verification

- ✅ Full `Pkg.test()` passes locally on Julia 1.12.
- ✅ `tutorials/agents/agents.jl` now runs end-to-end (previously errored at `@get_model`).
- ✅ Runic format check passes on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)